### PR TITLE
Doc string parser update

### DIFF
--- a/src/Bean.py
+++ b/src/Bean.py
@@ -44,7 +44,7 @@ class FunDefBean(GenericBean):
 
 class VarBean(GenericBean):
     
-    def __inti__(self, name, aType):
+    def __init__(self, name, aType):
         """
         @name:str
         @aType:str

--- a/src/DocStringParser.py
+++ b/src/DocStringParser.py
@@ -1,6 +1,6 @@
 '''
 Created: 10/14/14
-Updated: 10/27/14
+Updated: 10/30/14
 @author: Jake Albee
 '''
 import re
@@ -11,31 +11,38 @@ def parseDocString(docString,returnList = True):
     """Takes in a doc string in the form of a string and returns a list of VarBeans
     or a ScopeLevelBean. Defaults to returning a list of VarBeans
     @docString:string
+    @returnList:bool
     """
     lineList = docString.splitlines()
     for i in lineList:
         if not re.match('@.+', i, flags=0):
             lineList.remove(i)
     finalList = []
+    listWarn = '**WARNING** Lists can be of unknown types! '
+    dictWarn = '**WARNING** Dictionaries can be of unknown types! '
+    matchPattern = '\*\*?.*|.*\*\*?'
     for i in lineList:
         current = i[1:] #Remove the @
         current = current.replace(" ","") #Remove all spaces for easier parsing
         current = current.split(':')
         variables = current[0].split(',')
         currentType = current[1]
-        if currentType[0] == '*':
-            currentType='**WARNING** Lists can be of unknown types!' +  currentType
-        elif currentType[1] == '*':
-            currentType='**WARNING** Dictionaries can be of unknown types!' +  currentType
-        print(currentType)
+        
+        if re.search(matchPattern,currentType):
+            if currentType[1] == '*':
+                currentType= dictWarn +  currentType
+            elif currentType[0] == '*':
+                currentType= listWarn +  currentType
+            elif currentType[-2] == '*':
+                currentType= dictWarn +  currentType
+            elif currentType[-1] == '*':
+                currentType= listWarn +  currentType
+                
         for key in variables:
-            newBean = VarBean(key,currentType)
-            finalList.append(newBean)
+            finalList.append(VarBean(key,currentType))
             
-            
-    if returnList == True:
-        return finalList
+    if returnList == False:
+        return ScopeLevelBean(finalList)
     else:
-        #Returning a ScopeLevelBean
-        slb = ScopeLevelBean(finalList)
-        return slb
+        return finalList
+    


### PR DESCRIPTION
 Added the ability to check if a doc string is holding a list or dictionary type by checking for a \* or *\* at the beginning or end of the
variable type. Also added a return type parameter that defaults to
returning a list of VarBeans, non-default returns a ScopeLevelBean.

Currently throws errors when attempting to return a ScopeLevel as that
wasn't in the branch that I was working off of. 

Also removed some unnessecary assignments and re-assignments in hopes of
keeping memory usage down.

Also fixed a typo in Bean.py's init

This is to fix a bug and add an enhancement in #4 
