### PR TITLE
Doc String Parser Fix

### DIFF
--- a/src/DocStringParser.py
+++ b/src/DocStringParser.py
@@ -47,11 +47,19 @@ def parseDocString(docString,returnList = True):
                     mainVarType = 'tuple'
                 #Tuple handled.
                 elif currentType[-2] == '*':
-                    compType, valueType = currentType[:-2].split(':')
+                    try:
+                        compType, valueType = currentType[:-2].split(':')
+                    except:
+                        compType = currentType[:-2]
+                        valueType = compType
                     #List is [key,value]
                     mainVarType = 'dict'
                 elif currentType[1] == '*':
-                    compType, valueType = currentType[2:].split(':')
+                    try:
+                        compType, valueType = currentType[2:].split(':')
+                    except:
+                        compType = currentType[2:]
+                        valueType = compType
                     mainVarType = 'dict'
                 #Dicts handled
                 elif currentType[0] == '*':

--- a/src/TestAST.py
+++ b/src/TestAST.py
@@ -89,7 +89,7 @@ def _testAll(listOfFiles):
 
     
 if __name__ == '__main__':
-    testOne("../Test/Incorrect/MultiCol.py")
-    #testAllCorrect()
+    #testOne("../Test/Correct/MethodDef.py")
+    testAllCorrect()
     #testAllIncorrect()
     print("out main")


### PR DESCRIPTION
Added a try and except to dictionaries in the doc string parser. Worth looking at/talking about in our meeting. This way it at least does not default out if someone doesn't provide a key value pair in the doc strings, i.e. @dictName:**

We can talk about this at the meeting, I'm not sure what we should do in this case. I just noticed it was throwing an error so I put a fix in place.